### PR TITLE
docs: Add step to create docker container in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ We've handpicked the following stack for optimal performance, scalability, and d
 2. Generate **Google OAuth** credentials (default correct authorized URL should be set to: `http://localhost:3000/api/auth/callback/google`).
 3. Prepare `.env` and `apps/app/.env` files based on the `.env.shared` examples. Fill them with Google OAuth credentials.
 4. Install dependencies: `pnpm install`
-5. Launch Docker: `docker compose up -d`
-6. Fire up the Next.js app: `pnpm nx run app:serve`
-7. Dive in! Visit `https://localhost:3000` and start coding.
+5. Create Docker container: `docker volume create {PROJECT_NAME}-web-backend-db-data`. `PROJECT_NAME` needs to be the same as set in `.env` file in step 3.
+6. Launch Docker: `docker compose up -d`
+7. Fire up the Next.js app: `pnpm nx run app:serve`
+8. Dive in! Visit `https://localhost:3000` and start coding.
 
 ## 📂 **Project Structure**
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

<!-- (Bug fix, feature, docs update, ...) -->
Docs update to include creating docker container before trying to run `docker compose up -d` to avoid getting error `external volume "{PROJECT_NAME}-web-backend-db-data" not found`

### What is the current behavior?

<!--(You can also link to an open issue here) -->
User gets error while trying to run `docker compose`, because they don't know they need to create the container first

### What is the new behavior?
User knows what command to run to create correct docker container before trying to run it.

### Does this PR introduce a breaking change?

<!-- (What changes might users need to make in their application due to this PR?) -->

### Other information:
